### PR TITLE
Fix circular reqs!

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,4 +1,5 @@
 require 'sqlite3'
-require_relative '../lib/student'
+
+require_relative '../lib/student' unless defined?(STUDENT_RB)
 
 DB = {:conn => SQLite3::Database.new("db/students.db")}

--- a/lib/student.rb
+++ b/lib/student.rb
@@ -1,3 +1,4 @@
+STUDENT_RB = nil
 require_relative "../config/environment.rb"
 
 class Student


### PR DESCRIPTION
Fixing this warning:

```
// ♥ rspec -w
/Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/config/environment.rb:2: warning: /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/config/environment.rb:2: warning: loading in progress, circular require considered harmful - /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/lib/student.rb
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/bin/ruby_executable_hooks:24:in  `<main>'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/bin/ruby_executable_hooks:24:in  `eval'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/bin/rspec:23:in  `<main>'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/bin/rspec:23:in  `load'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/exe/rspec:4:in  `<top (required)>'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:45:in  `invoke'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:71:in  `run'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:86:in  `run'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:97:in  `setup'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:127:in  `configure'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration_options.rb:22:in  `configure'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration_options.rb:112:in  `process_options_into'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration_options.rb:112:in  `each'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration_options.rb:113:in  `block in process_options_into'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1519:in  `requires='
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1519:in  `each'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1519:in  `block in requires='
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:2034:in  `load_file_handling_errors'
        from /Users/flatironschool/.rvm/gems/ruby-2.6.1/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:2034:in  `require'
        from /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/spec/spec_helper.rb:1:in  `<top (required)>'
        from /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/spec/spec_helper.rb:1:in  `require_relative'
        from /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/lib/student.rb:1:in  `<top (required)>'
        from /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/lib/student.rb:1:in  `require_relative'
        from /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/config/environment.rb:2:in  `<top (required)>'
        from /Users/flatironschool/Documents/GitHub/orm-update-lab-nyc-web-060319/config/environment.rb:2:in  `require_relative'



```